### PR TITLE
Add default columns and option to copy columns from last sprint

### DIFF
--- a/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/column/model/mapper/SprintColumnMapper.kt
+++ b/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/column/model/mapper/SprintColumnMapper.kt
@@ -34,6 +34,13 @@ fun SprintColumn.toDTO(): SprintColumnResponse = SprintColumnResponse(
     columnIndex = columnIndex
 )
 
+fun SprintColumn.toNewSprintColumn(): NewSprintColumn = NewSprintColumn(
+    sprintId = sprintId,
+    name = name,
+    status = status,
+    columnIndex = columnIndex
+)
+
 // Request DTO -> NewSprintColumn (Domain Model)
 fun SprintColumnRequest.toModel(): NewSprintColumn = NewSprintColumn(
     sprintId = sprintId,

--- a/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/application/SprintApplication.kt
+++ b/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/application/SprintApplication.kt
@@ -3,12 +3,14 @@ package dev.ecckea.agilepath.backend.domain.sprint.application
 import dev.ecckea.agilepath.backend.domain.sprint.model.NewSprint
 import dev.ecckea.agilepath.backend.domain.sprint.model.Sprint
 import dev.ecckea.agilepath.backend.domain.sprint.service.SprintService
+import dev.ecckea.agilepath.backend.domain.column.service.SprintColumnService
 import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
 class SprintApplication(
     private val sprintService: SprintService,
+    private val sprintColumnService: SprintColumnService
 ) {
 
     fun getSprints(projectId: UUID): List<Sprint> {
@@ -20,7 +22,19 @@ class SprintApplication(
     }
 
     fun createSprint(sprint: NewSprint): Sprint {
-        return sprintService.createSprint(sprint)
+        val createdSprint = sprintService.createSprint(sprint)
+        if(sprint.copyLastSprintColumns) {
+            val lastSprint = sprintService.getSprints(sprint.projectId).lastOrNull()
+            if (lastSprint != null) {
+                sprintColumnService.copyColumnsFromLastSprint(lastSprint.id, createdSprint.id)
+            } else {
+                sprintColumnService.createDefaultColumns(createdSprint.id)
+            }
+        } else {
+            sprintColumnService.createDefaultColumns(createdSprint.id)
+        }
+        
+        return createdSprint
     }
 
     fun updateSprint(sprintId: UUID, sprint: NewSprint): Sprint {

--- a/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/dto/SprintRequest.kt
+++ b/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/dto/SprintRequest.kt
@@ -28,4 +28,7 @@ data class SprintRequest(
 
     @field:NotNull(message = "End date must not be null")
     val endDate: LocalDate,
+
+    @field:NotNull(message = "Copy last sprint columns must not be null")
+    val copyLastSprintColumns: Boolean = true,
 )

--- a/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/model/Mapper/SprintMapper.kt
+++ b/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/model/Mapper/SprintMapper.kt
@@ -68,7 +68,8 @@ fun SprintRequest.toModel() = NewSprint(
     name = name,
     goal = goal,
     startDate = startDate,
-    endDate = endDate
+    endDate = endDate,
+    copyLastSprintColumns = copyLastSprintColumns
 )
 
 // Create new Entity from NewSprint

--- a/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/model/NewSprint.kt
+++ b/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/sprint/model/NewSprint.kt
@@ -9,4 +9,5 @@ data class NewSprint(
     val goal: String? = null,
     val startDate: LocalDate,
     val endDate: LocalDate,
+    val copyLastSprintColumns: Boolean = false,
 )

--- a/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/story/dto/StoryRequest.kt
+++ b/backend/src/main/kotlin/dev/ecckea/agilepath/backend/domain/story/dto/StoryRequest.kt
@@ -13,11 +13,12 @@ data class StoryRequest(
     @field:TrimmedNotBlank(message = "Title name must not be blank")
     @field:Size(min = 3, max = 100, message = "Title name must be between 3 and 100 characters")
     val title: String,
-    @field:TrimmedNotBlank(message = "Description must not be blank")
+    
     @field:Size(max = 2000, message = "Description must be at most 2000 characters")
     @field:NoHtml(message = "Description must not contain HTML")
     val description: String?,
-    @field:TrimmedNotBlank(message = "Description must not be blank")
+    
+    @field:TrimmedNotBlank(message = "Status must not be blank")
     val status: String,
     @field:PositiveOrZero(message = "Priority must be 0 or greater")
     val priority: Int

--- a/frontend/src/components/project/NewSprintModal.tsx
+++ b/frontend/src/components/project/NewSprintModal.tsx
@@ -6,13 +6,14 @@ import { notifyError, notifySuccess } from "../../helpers/notify";
 import Input from "../generic/inputs/Input";
 import TextArea from "../generic/inputs/CustomTextArea";
 import { getNowDatePlusDays } from "../../helpers/timeHelpers";
+import ShowIf from "../generic/ShowIf";
 
 interface NewSprintModalProps {
   show: boolean;
   onClose: () => void;
 }
 function NewSprintModal(props: Readonly<NewSprintModalProps>) {
-  const { project, addSprint } = useCurrentProject();
+  const { project, sprints, addSprint } = useCurrentProject();
 
   const [name, setName] = useState<string>("");
   const [startDate, setStartDate] = useState<string>(new Date().toISOString().substring(0, 10));
@@ -20,6 +21,7 @@ function NewSprintModal(props: Readonly<NewSprintModalProps>) {
     getNowDatePlusDays(14).toISOString().substring(0, 10)
   );
   const [goal, setGoal] = useState<string>("");
+  const [copyLastSprintColumns, setCopyLastSprintColumns] = useState<boolean>(sprints.length > 0);
 
   const handleCreateNewSprint = () => {
     if (!project) return;
@@ -28,8 +30,10 @@ function NewSprintModal(props: Readonly<NewSprintModalProps>) {
       name: name,
       goal: goal,
       startDate: startDate,
-      endDate: endDate
+      endDate: endDate,
+      copyLastSprintColumns: copyLastSprintColumns
     };
+
     addSprint(tmp)
       .then(() => notifySuccess(`Successfully created sprint "${tmp.name}"`))
       .catch(() => notifyError("Something went wrong while creating sprint"));
@@ -86,6 +90,17 @@ function NewSprintModal(props: Readonly<NewSprintModalProps>) {
             className="w-full"
           />
         </div>
+        <ShowIf if={sprints.length > 0}>
+          <div className="flex items-center gap-1">
+            <Input
+              type="checkbox"
+              checked={copyLastSprintColumns}
+              onChange={(e) => setCopyLastSprintColumns(e.target.checked)}
+              className="size-5 accent-ap-lavender-900"
+            />
+            <div className="text-ap-onyx-400">Copy columns from last sprint</div>
+          </div>
+        </ShowIf>
       </div>
     </Modal>
   );

--- a/frontend/src/components/sprint/CreateColumnModal.tsx
+++ b/frontend/src/components/sprint/CreateColumnModal.tsx
@@ -23,8 +23,6 @@ export default function CreateColumnModal(props: CreateColumnModalProps) {
     return name === "";
   }, [name]);
 
-  console.log(columns);
-
   const handleCreateColumn = async () => {
     const endIndex = columns.length === 0 ? 0 : Math.max(...columns.map((c) => c.columnIndex)) + 1;
 

--- a/frontend/src/helpers/storyHelpers.ts
+++ b/frontend/src/helpers/storyHelpers.ts
@@ -2,5 +2,5 @@ import { IStory } from "../types/story.types";
 
 export function storySearchPredicate(s: IStory, searchVal: string) {
   const search = searchVal.toLowerCase();
-  return s.title.toLowerCase().includes(search) || s.id.includes(search);
+  return s.title?.toLowerCase().includes(search) || s.id.includes(search);
 }

--- a/frontend/src/hooks/projects/CurrentProjectProvider.tsx
+++ b/frontend/src/hooks/projects/CurrentProjectProvider.tsx
@@ -56,9 +56,7 @@ function CurrentProjectProvider(props: Readonly<PropsWithChildren>) {
 
   const addSprint = useCallback(
     (newSprint: INewSprint) => {
-      return post("/sprints", newSprint)
-        .then((sprint) => setSprints((prev) => [...prev, sprint]))
-        .catch(console.error);
+      return post("/sprints", newSprint).then((sprint) => setSprints((prev) => [...prev, sprint]));
     },
     [projectID]
   );

--- a/frontend/src/hooks/projects/ProjectProvider.tsx
+++ b/frontend/src/hooks/projects/ProjectProvider.tsx
@@ -32,9 +32,6 @@ function ProjectProvider({ children }: Readonly<PropsWithChildren>) {
       loader.add();
       return post("/projects", newProj)
         .then((proj) => setProjects([...projects, proj]))
-        .catch((e) => {
-          toast.error(e);
-        })
         .finally(loader.done);
     },
     [post, loader]

--- a/frontend/src/hooks/story/StoryProvider.tsx
+++ b/frontend/src/hooks/story/StoryProvider.tsx
@@ -15,9 +15,7 @@ function StoryProvider({ children }: Readonly<PropsWithChildren>) {
 
   const createStory = useCallback(
     (story: INewStory) => {
-      return post(`/stories`, story)
-        .then((res) => setStories((prev) => [...prev, res]))
-        .catch(console.error);
+      return post(`/stories`, story).then((res) => setStories((prev) => [...prev, res]));
     },
     [post]
   );

--- a/frontend/src/hooks/task/TaskProvider.tsx
+++ b/frontend/src/hooks/task/TaskProvider.tsx
@@ -28,18 +28,16 @@ function TaskProvider({ children }: Readonly<PropsWithChildren>) {
 
   const createTask = useCallback(
     (task: ITaskRequest) => {
-      return post("/tasks", task)
-        .then((res) => setTasks((prev) => [...prev, res]))
-        .catch(console.error);
+      return post("/tasks", task).then((res) => setTasks((prev) => [...prev, res]));
     },
     [post]
   );
 
   const updateTask = useCallback(
     (task: ITaskRequest, id: string) => {
-      return put(`/tasks/${id}`, task)
-        .then((res) => setTasks((prev) => prev.map((t) => (t.id === res.id ? res : t))))
-        .catch(console.error);
+      return put(`/tasks/${id}`, task).then((res) =>
+        setTasks((prev) => prev.map((t) => (t.id === res.id ? res : t)))
+      );
     },
     [put]
   );

--- a/frontend/src/types/sprint.types.ts
+++ b/frontend/src/types/sprint.types.ts
@@ -1,12 +1,12 @@
 export interface ISprint {
-  id: string; 
+  id: string;
   projectId: string;
   name: string;
-  goal?: string; 
+  goal?: string;
   startDate: string;
   endDate: string;
   createdBy: string;
-};
+}
 
 export interface INewSprint {
   projectId: string;
@@ -14,4 +14,5 @@ export interface INewSprint {
   goal?: string;
   startDate: string;
   endDate: string;
+  copyLastSprintColumns: boolean;
 }


### PR DESCRIPTION
Implement functionality to create default columns for new sprints and allow users to copy the column layout from the most recent sprint. This ensures a consistent starting point for sprint organization and enhances user experience.

Closes #38